### PR TITLE
Add support for custom roles

### DIFF
--- a/hermit.php
+++ b/hermit.php
@@ -3,13 +3,13 @@
 Plugin Name: Hermit X
 Plugin URI: https://blog.lwl12.com/read/hermit-x.html
 Description: 音乐播放器 Hermit music player build for wordpress with APlayer
-Version: 2.6.2.2048-beta
+Version: 2.6.2.4096-beta
 Author: Hermit X Developer Team
 Author URI: https://blog.lwl12.com/read/hermit-x.html#developer
 */
 
 define('HERMIT_FILE', __FILE__);
-define('HERMIT_VERSION', '2.6.2.2048-beta');
+define('HERMIT_VERSION', '2.6.2.4096-beta');
 define('HERMIT_URL', plugins_url('', __FILE__));
 define('HERMIT_PATH', dirname(__FILE__));
 define('HERMIT_ADMIN_URL', admin_url());

--- a/include/setting.php
+++ b/include/setting.php
@@ -198,28 +198,13 @@
 			<tr>
 				<th scope="row"><label>新建权限</label></th>
 				<td>
-					<?php
-                    $role_array = array(
-                        'subscriber'    => '订阅者',
-                        'author'        => '作者',
-                        'contributor'   => '投稿者',
-                        'editor'        => '编辑',
-                        'administrator' => '管理员'
-                    );
-
-                    foreach ($role_array as $key => $val) {
-                        ?>
+					<?php foreach (get_editable_roles() as $role => $details) { ?>
 						<label title="开启调试信息">
 							<input type="checkbox" name="hermit_setting[roles][]"
-							       value="<?php echo $key; ?>" <?php if (in_array($key, $this->settings('roles'))) {
-                            echo 'checked="checked"';
-                        } ?>/>
-							<span><?php echo $val; ?></span>
+							       value="<?php echo esc_attr($role); ?>" <?php checked(in_array(esc_attr($role), $this->settings( 'roles' ))); ?> />
+							<span><?php echo translate_user_role($details['name']); ?></span>
 						</label>
-					<?php
-
-                    }
-                    ?>
+					<?php } ?>
 					<p class="description">默认：<strong>管理员权限</strong> 才可以在新建或编辑文章时添加音乐</p>
 				</td>
 			</tr>


### PR DESCRIPTION
当前插件的权限设置中的用户角色是硬编码的。

通过使用 `get_editable_roles()` 实现对自定义角色的支持。